### PR TITLE
getService() deprecated and bootstrap "hide" class collision fix

### DIFF
--- a/ComponentTreePanel.php
+++ b/ComponentTreePanel.php
@@ -87,7 +87,7 @@ class ComponentTreePanel extends CompilerExtension implements IBarPanel {
 	public static function register($container) {
 		$panel = new self;
 		Debugger::$bar->addPanel($panel);
-		$application = $container->getService('application');
+		$application = $container->getContext()->getService('application');
 		$application->onResponse[] = callback(array($panel, 'getResponseCb'));
 	}
 

--- a/blocks.latte
+++ b/blocks.latte
@@ -8,12 +8,12 @@
 
 {define #template}
 	{=jasir\ComponentTreePanel::relativizePath($file, 'strong') |noescape}{include #editlink file=>$file} {include #toggler}
-		<ul class="hide">
+		<ul class="nette-collapsed">
 			<li><i>instance of </i>{include #editlink title=>get_class($t), file=>$t->getReflection()->getFileName()}
 			{include #dump object => $t}
 			{if $showSources && $t instanceOf \Nette\Templating\IFileTemplate}
 			<li>Source code {include #toggler}
-				<pre class="hide source">
+				<pre class="nette-collapsed source">
 {$t->getSource()}
 				</pre>
 			{/if}
@@ -27,7 +27,7 @@
 	{default title = 'Dump'}
 	{if $dumps}
 		<li>{$title} {include #toggler}
-		<ul class="hide"><li>
+		<ul class="nette-collapsed"><li>
 			<div class="ct-dump">{= Nette\Diagnostics\Dumper::toHtml($object) |noescape}</div>
 		</ul>
 	{/if}
@@ -54,7 +54,7 @@
 	{default title = 'Source code'}
 	{if $showSources}
 		<li>{$title} {include #toggler}
-		<ul class="hide">
+		<ul class="nette-collapsed">
 			<li>
 			{include #plainsource object => $object}
 		</ul>
@@ -70,6 +70,7 @@
 
 
 {define #methods}
+{dump $object}
 	{default showEmpty = FALSE}
 	{default hideMethods = []}
 
@@ -87,7 +88,7 @@
 						{/if}
 						{if $showSources}
 							{include #toggler}
-							<div class="hide">
+							<div class="nette-collapsed">
 								{include #plainsource, object => $method}
 							</div>
 						{/if}

--- a/component.latte
+++ b/component.latte
@@ -23,7 +23,7 @@
 		[{=get_class($object)}]
 	</a>
 
-	<ul {if !$opened}class="hide"{/if} id="{$id |noescape}">
+	<ul {if !$opened}class="nette-collapsed"{/if} id="{$id |noescape}">
 		<div style="padding:0.5em;">
 			<ul>
 
@@ -46,7 +46,7 @@
 				{if count($params) > 0}
 
 					<li><span title="persistent parameters are marked with P icon">Parameters ({=count($params)})</span>{include #toggler open=>$parametersOpen}
-					<ul n:class="!$parametersOpen ? hide">
+					<ul n:class="!$parametersOpen ? nette-collapsed">
 						{foreach $params as $name =>$param}
 						<li>
 							{if $param['persistent']}
@@ -55,7 +55,7 @@
 									<strong>(default value)</strong>
 								{/if}
 								{include #toggler}
-								<ul class="hide">
+								<ul class="nette-collapsed">
 									<li>
 										{var refl = new \Nette\Reflection\ClassType($param['meta']['since']) }
 										persistent parameter declared in
@@ -66,7 +66,7 @@
 								</ul>
 							{else}
 								<strong>{$name}</strong> = <code>{?var_dump($param['value'])}</code> {include #toggler}
-								<ul class="hide">
+								<ul class="nette-collapsed">
 									<li>full name: <strong>{$object->getParameterId($name)}</strong>
 								</ul>
 
@@ -116,7 +116,7 @@
 					</li>
 					<li>
 						Other methods {include #toggler}
-						<ul class="hide">
+						<ul class="nette-collapsed">
 
 							{* aciton<action>, beforeRender<view> *}
 							{if $object instanceof \Nette\Application\IPresenter}

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "keywords": ["nette", "debugging", "presenter", "component"],
     "require": {
         "php": ">= 5.3.0",
-        "nette/nette": "2.1.*"
+        "nette/nette": ">= 2.1.*"
     },
     "autoload": {
             "classmap": ["ComponentTreePanel.php", "DebugTemplate.php"]


### PR DESCRIPTION
getService() is formally deprecated, so for now its better to use getContext()->getService()
getContext() is not yet formally deprecated - more info (cs): http://phpfashion.com/prejdete-na-nette-2-1#comment-20571
- class "hide" collided with twitter bootstrap hide and wasnt possible to toggle the elements, so i used "nette-collapsed" class instead
